### PR TITLE
Fix autoClear logic in POC cross handling

### DIFF
--- a/Indicator.pine
+++ b/Indicator.pine
@@ -16,6 +16,7 @@ pocWidth         = input.int(2,          "POC Line Width",       minval=1, maxva
 showLabel        = input.bool(true,       "Show POC Label")
 showDelta        = input.bool(false,      "Show Delta Label")
 enableDoubleCross = input.bool(true,     "Enable Double Cross Logic")
+autoClear        = input.bool(false,     "Auto Clear Crossed Lines")
 
 // === Globals
 var line[]  pocLines      = array.new_line()
@@ -100,27 +101,32 @@ if endSession
 
 // === Логика пересечений
 if array.size(pocLines) > 0
-    for i = 0 to array.size(pocLines) - 1
+    for i = array.size(pocLines) - 1 to 0 by -1
         if array.get(pocActive, i)
             price_i   = array.get(pocPrices, i)
             prevClose = close[1]
             currClose = close
             crossed = (prevClose < price_i and currClose >= price_i) or (prevClose > price_i and currClose <= price_i)
-            if enableDoubleCross
-                crossCount = array.get(pocCrossCount, i)
-                if crossed and crossCount == 0
-                    lnC = array.get(pocLines, i)
-                    line.set_style(lnC, line.style_dashed)
-                    array.set(pocCrossCount, i, 1)
-                else if crossed and crossCount == 1
-                    lnC = array.get(pocLines, i)
-                    line.set_x2(lnC, bar_index)
-                    line.set_extend(lnC, extend.none)
-                    array.set(pocCrossCount, i, 2)
-                    array.set(pocActive, i, false)
-            else
-                if crossed
-                    lnC = array.get(pocLines, i)
-                    line.set_x2(lnC, bar_index)
-                    line.set_extend(lnC, extend.none)
-                    array.set(pocActive, i, false)
+            if crossed
+                lnC = array.get(pocLines, i)
+                if autoClear
+                    line.delete(lnC)
+                    array.remove(pocLines, i)
+                    array.remove(pocPrices, i)
+                    array.remove(pocActive, i)
+                    array.remove(pocCrossCount, i)
+                else
+                    if enableDoubleCross
+                        crossCount = array.get(pocCrossCount, i)
+                        if crossCount == 0
+                            line.set_style(lnC, line.style_dashed)
+                            array.set(pocCrossCount, i, 1)
+                        else if crossCount == 1
+                            line.set_x2(lnC, bar_index)
+                            line.set_extend(lnC, extend.none)
+                            array.set(pocCrossCount, i, 2)
+                            array.set(pocActive, i, false)
+                    else
+                        line.set_x2(lnC, bar_index)
+                        line.set_extend(lnC, extend.none)
+                        array.set(pocActive, i, false)


### PR DESCRIPTION
## Summary
- add `autoClear` input option
- remove crossed POC lines only when `autoClear` is enabled and a cross happens
- iterate through POC arrays backwards so indices remain valid during deletions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852c81b330883238786c8b66ad081e2